### PR TITLE
Use private copy of memmem() to find the UUID

### DIFF
--- a/src/memmem.h
+++ b/src/memmem.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2008 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/*
+ * This uses the "Not So Naive" algorithm, a very simple but
+ * usually effective algorithm, see:
+ * http://www-igm.univ-mlv.fr/~lecroq/string/
+ */
+#include <string.h>
+
+static void *memmem(const void *haystack, size_t n, const void *needle, size_t m)
+{
+    if (m > n || !m || !n)
+        return NULL;
+    if (__builtin_expect((m > 1), 1)) {
+        const unsigned char*  y = (const unsigned char*) haystack;
+        const unsigned char*  x = (const unsigned char*) needle;
+        size_t                j = 0;
+        size_t                k = 1, l = 2;
+        if (x[0] == x[1]) {
+            k = 2;
+            l = 1;
+        }
+        while (j <= n-m) {
+            if (x[1] != y[j+1]) {
+                j += k;
+            } else {
+                if (!memcmp(x+2, y+j+2, m-2) && x[0] == y[j])
+                    return (void*) &y[j];
+                j += l;
+            }
+        }
+    } else {
+        /* degenerate case */
+        return memchr(haystack, ((unsigned char*)needle)[0], n);
+    }
+    return NULL;
+}

--- a/src/sei-timestamp.c
+++ b/src/sei-timestamp.c
@@ -6,6 +6,7 @@
 #include <sys/time.h>
 
 #include "sei-timestamp.h"
+#include "memmem.h"
 
 int g_sei_timestamping = 0;
 
@@ -60,16 +61,16 @@ int sei_timestamp_field_set(unsigned char *buffer, int lengthBytes, uint32_t nr,
 
 int ltn_uuid_find(const unsigned char *buf, unsigned int lengthBytes)
 {
+	void *result;
+
 	if (lengthBytes < SEI_TIMESTAMP_PAYLOAD_LENGTH)
 		return -1;
 
-	for (int i = 0; i <= (lengthBytes - (int)SEI_TIMESTAMP_PAYLOAD_LENGTH); i++) {
-		if (memcmp(buf + i, &ltn_uuid_sei_timestamp[0], sizeof(ltn_uuid_sei_timestamp)) == 0) {
-			return i;
-		}
-	}
-
-	return -1;
+	result = memmem(buf, lengthBytes, ltn_uuid_sei_timestamp, sizeof(ltn_uuid_sei_timestamp));
+	if (result)
+		return (result - (void *)(buf));
+	else
+		return -1;
 }
 
 int sei_timestamp_field_get(const unsigned char *buffer, int lengthBytes, uint32_t nr, uint32_t *value)


### PR DESCRIPTION
The current implementation of the routine which searches for the LTN UUID SEI message is quite expensive, and doesn't scale well to streams that are 200Mbps+.

Switch to using memmem() to find the byte array.  While different libc versions include a version of this function (e.g. glibc has it if GNU_SOURCE is defined), using our own version ensures the function is available (as it's not part of the POSIX standard), and that the performance of the implementation is consistent regardless of platform.