### PR TITLE
Rename memmem to ltn_memmem

### DIFF
--- a/src/memmem.h
+++ b/src/memmem.h
@@ -32,7 +32,7 @@
  */
 #include <string.h>
 
-static void *memmem(const void *haystack, size_t n, const void *needle, size_t m)
+static void *ltn_memmem(const void *haystack, size_t n, const void *needle, size_t m)
 {
     if (m > n || !m || !n)
         return NULL;

--- a/src/sei-timestamp.c
+++ b/src/sei-timestamp.c
@@ -67,7 +67,7 @@ int ltn_uuid_find(const unsigned char *buf, unsigned int lengthBytes)
 	if (lengthBytes < SEI_TIMESTAMP_PAYLOAD_LENGTH)
 		return -1;
 
-	result = memmem(buf, lengthBytes, ltn_uuid_sei_timestamp, sizeof(ltn_uuid_sei_timestamp));
+	result = ltn_memmem(buf, lengthBytes, ltn_uuid_sei_timestamp, sizeof(ltn_uuid_sei_timestamp));
 	if (result)
 		return (result - (void *)(buf));
 	else


### PR DESCRIPTION
GLibC 2.38 and later makes `memmem` available by default, conflicting with our version.