### PR TITLE
smoother: Fix byte_array_append reallocation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-
     // Configure glob patterns for excluding files and folders.
     "files.exclude": {
         "**/.git": true,
@@ -38,5 +37,6 @@
         "limits": "cpp",
         "type_traits": "cpp",
         "utility": "cpp"
-    }
+    },
+    "editor.formatOnSave": false
 }

--- a/src/smoother-pcr.c
+++ b/src/smoother-pcr.c
@@ -65,14 +65,17 @@ void byte_array_free(struct byte_array_s *ba)
 
 int byte_array_append(struct byte_array_s *ba, const uint8_t *buf, int lengthBytes)
 {
-	if (ba->lengthBytes + lengthBytes > ba->maxLengthBytes) {
-		ba->buf = realloc(ba->buf, ba->lengthBytes + lengthBytes);
-		ba->maxLengthBytes += lengthBytes;
+	int newLengthBytes = ba->lengthBytes + lengthBytes;
+
+	if (newLengthBytes > ba->maxLengthBytes) {
+		/* XXX: consider exponential reallocation */
+		ba->buf = realloc(ba->buf, newLengthBytes);
+		ba->maxLengthBytes = newLengthBytes;
 	}
 	memcpy(ba->buf + ba->lengthBytes, buf, lengthBytes);
-	ba->lengthBytes += lengthBytes;
+	ba->lengthBytes = newLengthBytes;
 
-	return lengthBytes;
+	return newLengthBytes;
 }
 
 void byte_array_trim(struct byte_array_s *ba, int lengthBytes)

--- a/src/smoother-rtp.c
+++ b/src/smoother-rtp.c
@@ -67,14 +67,17 @@ static void byte_array_free(struct byte_array_s *ba)
 
 static int byte_array_append(struct byte_array_s *ba, const uint8_t *buf, int lengthBytes)
 {
-	if (ba->lengthBytes + lengthBytes > ba->maxLengthBytes) {
-		ba->buf = realloc(ba->buf, ba->lengthBytes + lengthBytes);
-		ba->maxLengthBytes += lengthBytes;
+	int newLengthBytes = ba->lengthBytes + lengthBytes;
+
+	if (newLengthBytes > ba->maxLengthBytes) {
+		/* XXX: consider exponential reallocation */
+		ba->buf = realloc(ba->buf, newLengthBytes);
+		ba->maxLengthBytes = newLengthBytes;
 	}
 	memcpy(ba->buf + ba->lengthBytes, buf, lengthBytes);
-	ba->lengthBytes += lengthBytes;
+	ba->lengthBytes = newLengthBytes;
 
-	return lengthBytes;
+	return newLengthBytes;
 }
 
 static void byte_array_trim(struct byte_array_s *ba, int lengthBytes)


### PR DESCRIPTION
- **vscode: Disable `formatOnSave`**    
  The default formatting isn't used by the code base.

- **smoother: Fix `byte_array_append` reallocation**    
  We were miscalculating the new `maxLengthBytes`, leading to buffer
  overflows and crashes.
