### PR TITLE
PCR writing fixes

### DIFF
--- a/src/libltntstools/ts.h
+++ b/src/libltntstools/ts.h
@@ -149,6 +149,14 @@ static inline uint8_t ltntstools_continuity_counter(const uint8_t *pkt)
 }
 
 /**
+ * @brief       Write a PCR value into a byte array conformant to the PCR field in MPEG-TS header (48-bit base+reserved+ext)
+ * @param[out]  uint8_t *dst - Pointer to insert into (e.g. "pkt + 6")
+ * @param[in]   int lengthBytes - Byte range of dst to not exceed
+ * @param[in]   uint64_t pcr - PCR value to write into dst
+ */
+void ltntstools_pcr_packTo(uint8_t *dst, int lengthBytes, uint64_t pcr);
+
+/**
  * @brief       In a SCR/PCR clock, subtract 'from' from 'to', compensate for a clock
  *              wrap and return a positive number of ticks.
  * @param[in]   int64_t from - tick value

--- a/src/ts.c
+++ b/src/ts.c
@@ -61,7 +61,7 @@ void ltntstools_pcr_packTo(uint8_t *dst, int lengthBytes, uint64_t pcr)
 
 	/* Base is 90KHz clock, ext is 27MHz clock */
 	uint64_t base = (pcr / 300);
-	uint64_t ext = pcr & 0x1ff;
+	uint64_t ext = (pcr % 300);
 
 	*(dst + 0)  = base >> 25LL;
 	*(dst + 1)  = base >> 17LL;


### PR DESCRIPTION
This patch series contains two patches related to writing PCR values into packets.  One patch addressed a small math error in the value written, while the other exposes the function in the public API so it can be used by applications.