### PR TITLE
Almalinux 10.1 compiler warnings

### DIFF
--- a/src/pes.c
+++ b/src/pes.c
@@ -648,7 +648,7 @@ int ltn_pes_packet_writer_init(struct ltn_pes_packet_writer_ctx *ctx, const char
 		return -1;
 
 	ctx->nr = 0;
-	strncpy(&ctx->dirname[0], dirname, sizeof(ctx->dirname));
+	snprintf(ctx->dirname, sizeof(ctx->dirname), "%s", dirname);
 
 	return 0; /* Success */
 }

--- a/src/pes.c
+++ b/src/pes.c
@@ -667,7 +667,7 @@ int ltn_pes_packet_save_es(struct ltn_pes_packet_writer_ctx *ctx, struct ltn_pes
 	uint32_t crc32 = 0;
 	ltntstools_getCRC32(pes->data, pes->dataLengthBytes, &crc32);
 
-	char fn[256];
+	char fn[512];
 
 	sprintf(fn, "%s/es-seq%014" PRIu64 "-pts%014" PRIu64 "-dts%014" PRIu64 "-len%08" PRIu32 "-crc%08x",
 		ctx->dirname,
@@ -704,7 +704,7 @@ int ltn_pes_packet_save_pes(struct ltn_pes_packet_writer_ctx *ctx, struct ltn_pe
 	uint32_t crc32 = 0;
 	ltntstools_getCRC32(pes->rawBuffer, pes->rawBufferLengthBytes, &crc32);
 
-	char fn[256];
+	char fn[512];
 
 	sprintf(fn, "%s/pes-seq%014" PRIu64 "-pts%014" PRIu64 "-dts%014" PRIu64 "-len%08" PRIu32 "-crc%08x",
 		ctx->dirname,

--- a/src/stats.c
+++ b/src/stats.c
@@ -468,7 +468,7 @@ int ltntstools_pid_stats_alloc(struct ltntstools_stream_statistics_s **ctx)
 
 void ltntstools_pid_stats_free(struct ltntstools_stream_statistics_s *stream)
 {
-	if (!stream || !stream->pids)
+	if (!stream)
 		return;
 
 	if (stream->packetIntervals) {

--- a/src/streammodel.c
+++ b/src/streammodel.c
@@ -508,7 +508,7 @@ size_t ltntstools_streammodel_write(void *hdl, const unsigned char *pkt, int pac
 {
 	struct streammodel_ctx_s *ctx = (struct streammodel_ctx_s *)hdl;
 
-	if (!ctx || !pkt || packetCount <= 0 || &ctx->rom_mutex == NULL)
+	if (!ctx || !pkt || packetCount <= 0)
 		return -1;
 
 	pthread_mutex_lock(&ctx->rom_mutex);


### PR DESCRIPTION
Fixed various compiler warnings from gcc 14.3.1 when compiling the library under almalinux 10.1.